### PR TITLE
Feature/in the file under d

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "com.mattfeury.saucillator.android"
-        minSdkVersion 8
+        minSdkVersion 14
         targetSdkVersion 33
     }
 
@@ -15,5 +15,9 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
+    }
+
+    dependencies {
+        implementation 'com.android.support:documentfile:28.0.0'
     }
 }

--- a/app/src/main/java/com/mattfeury/saucillator/android/SauceEngine.java
+++ b/app/src/main/java/com/mattfeury/saucillator/android/SauceEngine.java
@@ -1,5 +1,11 @@
 package com.mattfeury.saucillator.android;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileWriter;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.concurrent.ConcurrentHashMap;
 
 import com.mattfeury.saucillator.android.R;
@@ -14,14 +20,20 @@ import com.mattfeury.saucillator.android.settings.Settings;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Dialog;
+import android.net.Uri;
 import android.os.Bundle;
 import android.os.Vibrator;
 import android.content.*;
 import android.content.pm.ActivityInfo;
 import android.content.res.Configuration;
+import android.support.v4.provider.DocumentFile;
+import android.text.Editable;
 import android.util.Log;
 import android.view.*;
 import android.view.View.OnTouchListener;
+import android.widget.EditText;
+
+import org.json.JSONObject;
 
 /*
  * Main activity for the App. This class has two main purposes:
@@ -105,6 +117,7 @@ public class SauceEngine extends Activity implements OnTouchListener {
         tabManager.addTab(new EqTab(audioEngine));
         tabManager.addTab(new PadTab(audioEngine));
         tabManager.addTab(new RecorderTab(audioEngine));
+        tabManager.addTab(new SettingsTab(audioEngine));
       }
     }
 
@@ -154,6 +167,14 @@ public class SauceEngine extends Activity implements OnTouchListener {
         super.onResume();
 
         audioEngine.playDac();
+    }
+
+    @Override
+    protected void onActivityResult (int requestCode, int resultCode, Intent data) {
+        if (requestCode == ActivityService.V1_INSTRUMENT_MIGRATION_REQUEST_CODE) {
+            InstrumentService.migrateV1Folder(this, data);
+        }
+
     }
 
     @Override

--- a/app/src/main/java/com/mattfeury/saucillator/android/services/ActivityService.java
+++ b/app/src/main/java/com/mattfeury/saucillator/android/services/ActivityService.java
@@ -11,6 +11,8 @@ public class ActivityService {
   private static Activity activity;
   private static boolean canService = false;
 
+  public static final int V1_INSTRUMENT_MIGRATION_REQUEST_CODE = 9;
+
   public static void setup(Activity appActivity) {
     activity = appActivity;
 

--- a/app/src/main/java/com/mattfeury/saucillator/android/services/InstrumentService.java
+++ b/app/src/main/java/com/mattfeury/saucillator/android/services/InstrumentService.java
@@ -469,9 +469,16 @@ public class InstrumentService {
         }
       }
     }
+    String msg;
+    if (numAttempted > 0) {
+      msg = "Migrated " + numSuccess + " synths successfully out of " + numAttempted + " total attempts.";
+    } else {
+      msg = "Did not find any synths to migrate. Are you sure you chose the right folder? Contact support for help if needed.";
+    }
+
     AlertDialog alertDialog = new AlertDialog.Builder(context).create();
     alertDialog.setTitle("Migration");
-    alertDialog.setMessage("Migrated " + numSuccess + " instruments successfully out of " + numAttempted + " total attempts.");
+    alertDialog.setMessage(msg);
     alertDialog.setButton(AlertDialog.BUTTON_NEUTRAL, "OK",
             new DialogInterface.OnClickListener() {
               public void onClick(DialogInterface dialog, int which) {

--- a/app/src/main/java/com/mattfeury/saucillator/android/sound/AudioEngine.java
+++ b/app/src/main/java/com/mattfeury/saucillator/android/sound/AudioEngine.java
@@ -268,17 +268,11 @@ public class AudioEngine {
     if (isRecording) {
       ActivityService.makeToast("Recording.");
     } else {
-      File saved = WavWriter.getLastFile();
+      String saved = WavWriter.getLastFile();
       if (saved == null) {
         ActivityService.makeToast("Stopped Recording. File could not be saved. I blew it.");
       } else {
-        ActivityService.makeToast("Stopped Recording. File saved at: " + saved.getAbsolutePath(), true);
-
-        Intent intent = new Intent(Intent.ACTION_SEND).setType("audio/*");
-        intent.putExtra(Intent.EXTRA_STREAM, Uri.fromFile(saved));
-
-        // TODO maybe turn this into a Service so we can lose the reference to SauceEngine
-        sauceEngine.startActivity(Intent.createChooser(intent, "Share to"));
+        ActivityService.makeToast("Stopped Recording. File saved at: " + saved, true);
       }
     }
 

--- a/app/src/main/java/com/mattfeury/saucillator/android/tabs/PadTab.java
+++ b/app/src/main/java/com/mattfeury/saucillator/android/tabs/PadTab.java
@@ -66,7 +66,18 @@ public class PadTab extends Tab {
         .withFocus(ViewService.isGridShowing())
         .withClear(true)
         .finish(),
-       baseNotePicker,
+      ButtonBuilder
+              .build(ButtonBuilder.Type.TOGGLE, "Show/Hide Visuals")
+              .withHandler(new Handler<Boolean>() {
+                public void handle(Boolean show) {
+                  ViewService.setVisuals(! ViewService.getVisualsToggle());
+                }
+              })
+              .withMargin(MARGIN_SIZE)
+              .withFocus(ViewService.getVisualsToggle())
+              .withClear(true)
+              .finish(),
+            baseNotePicker,
        baseOctavePicker
     );
   }  

--- a/app/src/main/java/com/mattfeury/saucillator/android/tabs/SettingsTab.java
+++ b/app/src/main/java/com/mattfeury/saucillator/android/tabs/SettingsTab.java
@@ -54,7 +54,7 @@ public class SettingsTab extends Tab {
     feedbackButton.setTextSize(TEXT_SIZE);
     feedbackButton.setClear(false);
 
-    final RectButton migrateButton = new RectButton("Migrate V1 Instruments") {
+    final RectButton migrateButton = new RectButton("Import Old Synths") {
       @Override
       public void handle(Object o) {
         super.handle(o);

--- a/app/src/main/java/com/mattfeury/saucillator/android/tabs/SettingsTab.java
+++ b/app/src/main/java/com/mattfeury/saucillator/android/tabs/SettingsTab.java
@@ -1,0 +1,136 @@
+package com.mattfeury.saucillator.android.tabs;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.media.MediaPlayer;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Environment;
+import android.provider.DocumentsContract;
+import android.support.v4.provider.DocumentFile;
+import android.view.View;
+
+import com.mattfeury.saucillator.android.R;
+import com.mattfeury.saucillator.android.services.ActivityService;
+import com.mattfeury.saucillator.android.services.VibratorService;
+import com.mattfeury.saucillator.android.services.ViewService;
+import com.mattfeury.saucillator.android.sound.AudioEngine;
+import com.mattfeury.saucillator.android.templates.Button;
+import com.mattfeury.saucillator.android.templates.Handler;
+import com.mattfeury.saucillator.android.templates.RectButton;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+public class SettingsTab extends Tab {
+
+  private static final int BORDER_SIZE = 5, MARGIN_SIZE = 15, TEXT_SIZE = 18;
+
+  private MediaPlayer secretSauce;
+
+  public SettingsTab(final AudioEngine engine) {
+    super("Settings", engine);
+
+    ActivityService.withActivity(new Handler<Activity>() {
+      public void handle(Activity activity) {
+        secretSauce = MediaPlayer.create(activity, R.raw.sauceboss);
+      }
+    });
+
+    SettingsTab self = this;
+    final RectButton feedbackButton = new RectButton("Send Feedback") {
+      @Override
+      public void handle(Object o) {
+        super.handle(o);
+        self.sendFeedbackEmail();
+      }
+    };
+    feedbackButton.setBorder(BORDER_SIZE);
+    feedbackButton.setMargin(MARGIN_SIZE);
+    feedbackButton.setTextSize(TEXT_SIZE);
+    feedbackButton.setClear(false);
+
+    final RectButton migrateButton = new RectButton("Migrate V1 Instruments") {
+      @Override
+      public void handle(Object o) {
+        super.handle(o);
+        self.migrateV1Instruments();
+      }
+    };
+    migrateButton.setBorder(BORDER_SIZE);
+    migrateButton.setMargin(MARGIN_SIZE);
+    migrateButton.setTextSize(TEXT_SIZE);
+    migrateButton.setClear(true);
+
+    final RectButton secretButton = new RectButton("Secret Sauce") {
+      @Override
+      public void handle(Object o) {
+        super.handle(o);
+
+        VibratorService.vibrate();
+        secretSauce.start();
+      }
+    };
+    secretButton.setBorder(BORDER_SIZE);
+    secretButton.setMargin(MARGIN_SIZE);
+    secretButton.setTextSize(TEXT_SIZE);
+    secretButton.setClear(true);
+
+    panel.addChild(
+        feedbackButton,
+        migrateButton,
+        secretButton
+    );
+  }
+
+  private void migrateV1Instruments() {
+    ActivityService.withActivity(new Handler<Activity>() {
+      public void handle(Activity activity) {
+        AlertDialog alertDialog = new AlertDialog.Builder(activity).create();
+        alertDialog.setTitle("Migration");
+        alertDialog.setMessage("Old versions of Saucillator saved instruments in a location that Android no longer supports.\n\nIf you'd like to re-import these instruments, tap Migrate below and then select the \"sauce\" -> \"instruments\" folder on your device.");
+        alertDialog.setButton(AlertDialog.BUTTON_POSITIVE, "Migrate",
+        new DialogInterface.OnClickListener() {
+          public void onClick(DialogInterface dialog, int which) {
+            dialog.dismiss();
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+
+              Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
+              activity.startActivityForResult(intent, ActivityService.V1_INSTRUMENT_MIGRATION_REQUEST_CODE);
+            } else {
+              ActivityService.makeToast("This version of android does not support migration");
+            }
+          }
+        });
+        alertDialog.setButton(AlertDialog.BUTTON_NEGATIVE, "Nevermind",
+                new DialogInterface.OnClickListener() {
+                  public void onClick(DialogInterface dialog, int which) {
+                    dialog.dismiss();
+                  }
+                }
+        );
+        alertDialog.show();
+
+      }
+    });
+
+  }
+
+  private void sendFeedbackEmail() {
+    ActivityService.withActivity(new Handler<Activity>() {
+      public void handle(Activity activity) {
+        Intent emailIntent = new Intent(android.content.Intent.ACTION_SEND);
+        emailIntent.putExtra(android.content.Intent.EXTRA_EMAIL, new String[]{activity.getResources().getString(R.string.feedback_email_address)});
+        emailIntent.putExtra(android.content.Intent.EXTRA_SUBJECT, new String[]{activity.getResources().getString(R.string.feedback_email_subject)});
+        emailIntent.setType("plain/text");
+        activity.startActivity(Intent.createChooser(emailIntent, "Send email..."));
+      }
+    });
+
+  }
+
+}

--- a/app/src/main/java/com/mattfeury/saucillator/android/tabs/SettingsTab.java
+++ b/app/src/main/java/com/mattfeury/saucillator/android/tabs/SettingsTab.java
@@ -92,7 +92,7 @@ public class SettingsTab extends Tab {
       public void handle(Activity activity) {
         AlertDialog alertDialog = new AlertDialog.Builder(activity).create();
         alertDialog.setTitle("Migration");
-        alertDialog.setMessage("Old versions of Saucillator saved instruments in a location that Android no longer supports.\n\nIf you'd like to re-import these instruments, tap Migrate below and then select the \"sauce\" -> \"instruments\" folder on your device.");
+        alertDialog.setMessage(activity.getResources().getString(R.string.instrument_migration_about));
         alertDialog.setButton(AlertDialog.BUTTON_POSITIVE, "Migrate",
         new DialogInterface.OnClickListener() {
           public void onClick(DialogInterface dialog, int which) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,9 +7,9 @@
     <string name="send_feedback_email_button">Send Feedback Email (sauce@mattfeury.com)</string>
 
     <string name="instrument_migration_about">
-    Old versions of Saucillator saved instruments in a location that Android no longer provides access to.\n
+    Old versions of Saucillator saved synths in a location that Android no longer provides access to.\n
     \n
-    If you\'d like to re-import these instruments, tap Migrate below and then select the "sauce" -> "instruments" folder on your device.
+    If you\'d like to re-import these synths, tap Migrate below and then select the "sauce" -> "instruments" folder on your device.
     </string>
     <string name="tutorial_text">
       The RIGHT SIDE of the screen is for PLAYING. Use your fingers to control the synthesizer(s) by touching

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,11 @@
     <string name="feedback_email_subject">Saucillator feedback</string>
     <string name="send_feedback_email_button">Send Feedback Email (sauce@mattfeury.com)</string>
 
+    <string name="instrument_migration_about">
+    Old versions of Saucillator saved instruments in a location that Android no longer provides access to.\n
+    \n
+    If you\'d like to re-import these instruments, tap Migrate below and then select the "sauce" -> "instruments" folder on your device.
+    </string>
     <string name="tutorial_text">
       The RIGHT SIDE of the screen is for PLAYING. Use your fingers to control the synthesizer(s) by touching
       the black, blank portion of the screen. You can use as many fingers as you choose. Volume is controlled by the X-axis


### PR DESCRIPTION
In the process of upgrading the min SDK version to keep us on the store, we broke file management. Android no longer allows file mgmt via traditional java File. we have to use SAF. this is generally good as we can just remove the permission but it breaks our existing instrument + recording functionality.

New here:
1. save recordings with the media sdk.
2. save instruments to internal app storage
3. give a migration tool to allow for old instruments on the "SD card" to be re-imported into the new storage space.
4. Add a new "settings" tab to the app since new android versions don't show the options menu where this stuff lived before.

Yes, this code is still very gross. No, i don't really care all that much (but am starting to)

